### PR TITLE
Add typo3cms language:update task

### DIFF
--- a/deployer/default/deploy/task/deploy.php
+++ b/deployer/default/deploy/task/deploy.php
@@ -58,6 +58,9 @@ task('deploy', [
     // Update database schema for TYPO3. Task from typo3_console extension.
     'typo3cms:database:updateschema',
 
+    // Update language files of all activated extensions. Task from typo3_console.
+    'typo3cms:language:update',
+
     // Standard deployer task.
     'deploy:symlink',
 

--- a/deployer/default/deploy/task/deploy.php
+++ b/deployer/default/deploy/task/deploy.php
@@ -58,8 +58,8 @@ task('deploy', [
     // Update database schema for TYPO3. Task from typo3_console extension.
     'typo3cms:database:updateschema',
 
-    // Update language files of all activated extensions. Task from typo3_console.
-    'typo3cms:language:update',
+    // If activated, update language files of all activated extensions. Task from typo3_console.
+    'check_language_update',
 
     // Standard deployer task.
     'deploy:symlink',

--- a/deployer/default/deploy/task/deploy_fast.php
+++ b/deployer/default/deploy/task/deploy_fast.php
@@ -52,6 +52,9 @@ task('deploy-fast', [
     // Update database schema for TYPO3. Task from typo3_console extension.
     'typo3cms:database:updateschema',
 
+    // Update language files of all activated extensions. Task from typo3_console.
+    'typo3cms:language:update',
+
     // Standard deployer task.
     'deploy:symlink',
 

--- a/deployer/default/deploy/task/deploy_fast.php
+++ b/deployer/default/deploy/task/deploy_fast.php
@@ -52,8 +52,8 @@ task('deploy-fast', [
     // Update database schema for TYPO3. Task from typo3_console extension.
     'typo3cms:database:updateschema',
 
-    // Update language files of all activated extensions. Task from typo3_console.
-    'typo3cms:language:update',
+    // If activated, update language files of all activated extensions. Task from typo3_console.
+    'check_language_update',
 
     // Standard deployer task.
     'deploy:symlink',

--- a/deployer/default/typo3cms/task/typo3cms_language_update.php
+++ b/deployer/default/typo3cms/task/typo3cms_language_update.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Deployer;
+
+task('typo3cms:language:update', function () {
+    $activeDir = test('[ -e {{deploy_path}}/release ]') ?
+        get('deploy_path') . '/release' :
+        get('deploy_path') . '/current';
+    run('cd ' . $activeDir . ' &&  {{bin/php}} {{bin/typo3cms}} language:update');
+});

--- a/deployer/default/typo3cms/task/typo3cms_language_update.php
+++ b/deployer/default/typo3cms/task/typo3cms_language_update.php
@@ -2,6 +2,12 @@
 
 namespace Deployer;
 
+task('check_language_update', function () {
+    if (get('typo3_language_update', false)) {
+        invoke('typo3cms:language:update');
+    }
+})->shallow();
+
 task('typo3cms:language:update', function () {
     $activeDir = test('[ -e {{deploy_path}}/release ]') ?
         get('deploy_path') . '/release' :


### PR DESCRIPTION
When there is another language configured in `LocalConfiguration.php`, the language files of all extensions need to be updated. I would suggest to add the task after the database update task. 