### PR TITLE
[TASK] Add path-parameter for TYPO3 source-folder

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -6,7 +6,10 @@ use SourceBroker\DeployerLoader\Load;
 
 class Loader
 {
-    public function __construct()
+    /**
+     * @param string $typo3Path optional path to typo3-source relative to project-root, default: 'public'
+     */
+    public function __construct($typo3Path = 'public')
     {
         /** @noinspection PhpIncludeInspection */
         require_once 'recipe/common.php';
@@ -18,7 +21,7 @@ class Loader
                 ['path' => 'vendor/sourcebroker/deployer-extended-typo3/deployer/default'],
                 [
                     'path' => 'vendor/sourcebroker/deployer-extended-typo3/deployer/' .
-                        $this->getTypo3MajorVersion($this->projectRootAbsolutePath())
+                        $this->getTypo3MajorVersion($this->projectRootAbsolutePath(), $typo3Path)
                 ]
             ]
         );
@@ -26,16 +29,17 @@ class Loader
 
     /**
      * @param $rootDir
+     * @param string $typo3Path path to typo3-source relative to project-root
      * @return int|null
      * @throws \Exception
      * @internal param $params
      */
-    public function getTypo3MajorVersion($rootDir)
+    public function getTypo3MajorVersion($rootDir, $typo3Path)
     {
         $typo3MajorVersion = null;
         $rootDir = rtrim($rootDir, '/');
         if(!file_exists($rootDir . '/typo3')) {
-            $rootDir = $rootDir . '/public';
+            $rootDir = $rootDir . '/' . $typo3Path;
         }
         if (file_exists($rootDir . '/typo3/backend.php')) {
             $typo3MajorVersion = 6;


### PR DESCRIPTION
When using `helhum/typo3-secure-web` TYPO3's source-folder is placed into `/private` but deployer-extended-typo3 assumes hard-coded public if sources are not found in project's root-path.
With this change one can configure the path via constructor-argument which is public by default to keep currently known handling.

relates #5 
closes #20 