### PR TITLE
[FEATURE] Add vendor to search path

### DIFF
--- a/src/Loader.php
+++ b/src/Loader.php
@@ -37,9 +37,11 @@ class Loader
 
         $changelogFilesRoot = glob($rootDir . '/typo3/sysext/core/Documentation/Changelog-*.rst');
         $changelogFilesRootSubDirs = glob($rootDir . '/*/typo3/sysext/core/Documentation/Changelog-*.rst');
+        $changelogFilesVendor = glob('vendor/typo3/cms-core/Documentation/Changelog-*.rst');
         $changelogFiles = array_merge(
             is_array($changelogFilesRoot) ? $changelogFilesRoot : [],
-            is_array($changelogFilesRootSubDirs) ? $changelogFilesRootSubDirs : []
+            is_array($changelogFilesRootSubDirs) ? $changelogFilesRootSubDirs : [],
+            is_array($changelogFilesVendor) ? $changelogFilesVendor : []
         );
 
         $changelogFilesIntegers = array_map(function ($changelogFile) {


### PR DESCRIPTION
Adding the vendor path to the search path fixes #22

#22 Make compatible with typo3/cms-composer-installers version 4.x

