### PR TITLE
[FEATURE] Extend database config for new SSL settings

### DIFF
--- a/deployer/10/set.php
+++ b/deployer/10/set.php
@@ -82,9 +82,7 @@ set('db_databases',
                             'ssl_ca' => 'TYPO3__DB__Connections__Default__ssl_ca',
                             'ssl_capath' => 'TYPO3__DB__Connections__Default__ssl_capath',
                             'ssl_cipher' => 'TYPO3__DB__Connections__Default__ssl_cipher',
-                            'driverOptions' => [
-                                'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
-                            ]
+                            'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
                         ]
                     );
             }

--- a/deployer/10/set.php
+++ b/deployer/10/set.php
@@ -77,6 +77,14 @@ set('db_databases',
                             'dbname' => 'TYPO3__DB__Connections__Default__dbname',
                             'user' => 'TYPO3__DB__Connections__Default__user',
                             'password' => 'TYPO3__DB__Connections__Default__password',
+                            'ssl_key' => 'TYPO3__DB__Connections__Default__ssl_key',
+                            'ssl_cert' => 'TYPO3__DB__Connections__Default__ssl_cert',
+                            'ssl_ca' => 'TYPO3__DB__Connections__Default__ssl_ca',
+                            'ssl_capath' => 'TYPO3__DB__Connections__Default__ssl_capath',
+                            'ssl_cipher' => 'TYPO3__DB__Connections__Default__ssl_cipher',
+                            'driverOptions' => [
+                                'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
+                            ]
                         ]
                     );
             }

--- a/deployer/11/set.php
+++ b/deployer/11/set.php
@@ -82,9 +82,7 @@ set('db_databases',
                             'ssl_ca' => 'TYPO3__DB__Connections__Default__ssl_ca',
                             'ssl_capath' => 'TYPO3__DB__Connections__Default__ssl_capath',
                             'ssl_cipher' => 'TYPO3__DB__Connections__Default__ssl_cipher',
-                            'driverOptions' => [
-                                'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
-                            ]
+                            'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
                         ]
                     );
             }

--- a/deployer/11/set.php
+++ b/deployer/11/set.php
@@ -77,6 +77,14 @@ set('db_databases',
                             'dbname' => 'TYPO3__DB__Connections__Default__dbname',
                             'user' => 'TYPO3__DB__Connections__Default__user',
                             'password' => 'TYPO3__DB__Connections__Default__password',
+                            'ssl_key' => 'TYPO3__DB__Connections__Default__ssl_key',
+                            'ssl_cert' => 'TYPO3__DB__Connections__Default__ssl_cert',
+                            'ssl_ca' => 'TYPO3__DB__Connections__Default__ssl_ca',
+                            'ssl_capath' => 'TYPO3__DB__Connections__Default__ssl_capath',
+                            'ssl_cipher' => 'TYPO3__DB__Connections__Default__ssl_cipher',
+                            'driverOptions' => [
+                                'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
+                            ]
                         ]
                     );
             }

--- a/deployer/7/set.php
+++ b/deployer/7/set.php
@@ -85,9 +85,7 @@ set('db_databases',
                         'ssl_ca' => 'TYPO3__DB__Connections__Default__ssl_ca',
                         'ssl_capath' => 'TYPO3__DB__Connections__Default__ssl_capath',
                         'ssl_cipher' => 'TYPO3__DB__Connections__Default__ssl_cipher',
-                        'driverOptions' => [
-                            'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
-                        ]
+                        'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
                     ]
                 ),
         ]

--- a/deployer/7/set.php
+++ b/deployer/7/set.php
@@ -80,6 +80,14 @@ set('db_databases',
                         'dbname' => 'TYPO3__DB__database',
                         'user' => 'TYPO3__DB__username',
                         'password' => 'TYPO3__DB__password',
+                        'ssl_key' => 'TYPO3__DB__Connections__Default__ssl_key',
+                        'ssl_cert' => 'TYPO3__DB__Connections__Default__ssl_cert',
+                        'ssl_ca' => 'TYPO3__DB__Connections__Default__ssl_ca',
+                        'ssl_capath' => 'TYPO3__DB__Connections__Default__ssl_capath',
+                        'ssl_cipher' => 'TYPO3__DB__Connections__Default__ssl_cipher',
+                        'driverOptions' => [
+                            'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
+                        ]
                     ]
                 ),
         ]

--- a/deployer/8/set.php
+++ b/deployer/8/set.php
@@ -85,9 +85,7 @@ set('db_databases',
                         'ssl_ca' => 'TYPO3__DB__Connections__Default__ssl_ca',
                         'ssl_capath' => 'TYPO3__DB__Connections__Default__ssl_capath',
                         'ssl_cipher' => 'TYPO3__DB__Connections__Default__ssl_cipher',
-                        'driverOptions' => [
-                            'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
-                        ]
+                        'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
                     ]
                 ),
         ]

--- a/deployer/8/set.php
+++ b/deployer/8/set.php
@@ -80,6 +80,14 @@ set('db_databases',
                         'dbname' => 'TYPO3__DB__Connections__Default__dbname',
                         'user' => 'TYPO3__DB__Connections__Default__user',
                         'password' => 'TYPO3__DB__Connections__Default__password',
+                        'ssl_key' => 'TYPO3__DB__Connections__Default__ssl_key',
+                        'ssl_cert' => 'TYPO3__DB__Connections__Default__ssl_cert',
+                        'ssl_ca' => 'TYPO3__DB__Connections__Default__ssl_ca',
+                        'ssl_capath' => 'TYPO3__DB__Connections__Default__ssl_capath',
+                        'ssl_cipher' => 'TYPO3__DB__Connections__Default__ssl_cipher',
+                        'driverOptions' => [
+                            'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
+                        ]
                     ]
                 ),
         ]

--- a/deployer/9/set.php
+++ b/deployer/9/set.php
@@ -75,6 +75,14 @@ set('db_databases',
                             'dbname' => 'TYPO3__DB__Connections__Default__dbname',
                             'user' => 'TYPO3__DB__Connections__Default__user',
                             'password' => 'TYPO3__DB__Connections__Default__password',
+                            'ssl_key' => 'TYPO3__DB__Connections__Default__ssl_key',
+                            'ssl_cert' => 'TYPO3__DB__Connections__Default__ssl_cert',
+                            'ssl_ca' => 'TYPO3__DB__Connections__Default__ssl_ca',
+                            'ssl_capath' => 'TYPO3__DB__Connections__Default__ssl_capath',
+                            'ssl_cipher' => 'TYPO3__DB__Connections__Default__ssl_cipher',
+                            'driverOptions' => [
+                                'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
+                            ]
                         ]
                     );
             }

--- a/deployer/9/set.php
+++ b/deployer/9/set.php
@@ -80,9 +80,7 @@ set('db_databases',
                             'ssl_ca' => 'TYPO3__DB__Connections__Default__ssl_ca',
                             'ssl_capath' => 'TYPO3__DB__Connections__Default__ssl_capath',
                             'ssl_cipher' => 'TYPO3__DB__Connections__Default__ssl_cipher',
-                            'driverOptions' => [
-                                'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
-                            ]
+                            'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
                         ]
                     );
             }

--- a/src/Drivers/Typo3CmsDriver.php
+++ b/src/Drivers/Typo3CmsDriver.php
@@ -16,8 +16,13 @@ class Typo3CmsDriver
         exec($this->getPhpExecCommand() . ' ./vendor/bin/typo3cms configuration:showactive DB --json', $output,
             $resultCode);
         if ($resultCode === 0) {
-            return json_decode(implode("\n", $output), true, 512,
+            $config = json_decode(implode("\n", $output), true, 512,
                 JSON_THROW_ON_ERROR)['Connections'][$databaseConfiguration];
+            $flattenedConfig = [];
+            array_walk_recursive($config, function ($a, $b) use (&$flattenedConfig) {
+                $flattenedConfig[$b] = $a;
+            });
+            return $flattenedConfig;
         }
         throw new ConfigurationException('typo3cms configuration:showactive returned error code: "' . $resultCode . '"');
     }

--- a/src/Drivers/Typo3CmsDriver.php
+++ b/src/Drivers/Typo3CmsDriver.php
@@ -18,11 +18,8 @@ class Typo3CmsDriver
         if ($resultCode === 0) {
             $config = json_decode(implode("\n", $output), true, 512,
                 JSON_THROW_ON_ERROR)['Connections'][$databaseConfiguration];
-            $flattenedConfig = [];
-            array_walk_recursive($config, function ($a, $b) use (&$flattenedConfig) {
-                $flattenedConfig[$b] = $a;
-            });
-            return $flattenedConfig;
+            $config['flags'] = $config['driverOptions']['flags'] ?? 0;
+            return $config;
         }
         throw new ConfigurationException('typo3cms configuration:showactive returned error code: "' . $resultCode . '"');
     }


### PR DESCRIPTION
In case deployer-extended-database will merge [this PR](https://github.com/sourcebroker/deployer-extended-database/pull/22), this change will make use of the new configuration options.

* Typo3CmsDriver needed little adjustments to correctly pass flags inside the `driverOptions` array
* ssl_* defaults have been set from the typical TYPO3 database path