### PR TITLE
[FEATURE] TYPO3 v12 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "helhum/typo3-console": "^4.9 || ^5.5 || ^6 || ^7",
+    "helhum/typo3-console": "^4.9 || ^5.5 || ^6 || ^7 || ^8",
     "helhum/dotenv-connector": "^1.1 || ^2.3 || ^3",
     "symfony/dotenv": "^3.3 || ^4 || ^5 || ^6",
     "deployer/deployer": "~7.0",

--- a/deployer/12/set.php
+++ b/deployer/12/set.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Deployer;
+
+set('bin/typo3cms', './vendor/bin/typo3');
+set('local/bin/typo3cms', './vendor/bin/typo3');
+
+set('web_path', 'public/');
+
+set('composer_channel', 2);
+
+set('shared_dirs', function () {
+    return [
+        get('web_path') . 'fileadmin',
+        get('web_path') . 'uploads',
+        get('web_path') . 'typo3temp/assets/_processed_',
+        get('web_path') . 'typo3temp/assets/images',
+        !empty(get('web_path')) ? 'var/log' : 'typo3temp/var/log',
+        !empty(get('web_path')) ? 'var/transient' : 'typo3temp/var/transient',
+    ];
+});
+
+// Look on https://github.com/sourcebroker/deployer-extended#buffer-start for docs
+set('buffer_config', function () {
+    return [
+        'index.php' => [
+            'entrypoint_filename' => get('web_path') . 'index.php',
+        ],
+        'typo3/index.php' => [
+            'entrypoint_filename' => get('web_path') . 'typo3/index.php',
+        ],
+        'typo3/install.php' => [
+            'entrypoint_filename' => get('web_path') . 'typo3/install.php',
+        ]
+    ];
+});
+
+// Look https://github.com/sourcebroker/deployer-extended-database for docs
+set('db_default', [
+    'truncate_tables' => [
+        // Do not truncate caching tables "cache_imagesizes" as the image settings are not changed frequently and regenerating images is processor extensive.
+        '(?!cache_imagesizes)cache_.*',
+    ],
+    'ignore_tables_out' => [
+        'cf_.*',
+        'cache_.*',
+        'be_sessions',
+        'fe_sessions',
+        'fe_session_data',
+        'sys_file_processedfile',
+        'sys_history',
+        'sys_log',
+        'sys_refindex',
+        'tx_devlog',
+        'tx_extensionmanager_domain_model_extension',
+        'tx_powermail_domain_model_mail',
+        'tx_powermail_domain_model_answer',
+        'tx_solr_.*',
+        'tx_crawler_queue',
+        'tx_crawler_process',
+    ],
+    'post_sql_in' => '',
+    'post_sql_in_markers' => ''
+]);
+
+// Look https://github.com/sourcebroker/deployer-extended-database for docs
+set('db_databases',
+    [
+        'database_default' => [
+            get('db_default'),
+            function () {
+                if (get('driver_typo3cms', false)) {
+                    return (new \SourceBroker\DeployerExtendedTypo3\Drivers\Typo3CmsDriver)->getDatabaseConfig();
+                }
+                return !empty($_ENV['IS_DDEV_PROJECT']) ? get('db_ddev_database_config') :
+                    (new \SourceBroker\DeployerExtendedTypo3\Drivers\Typo3EnvDriver)->getDatabaseConfig(
+                        [
+                            'host' => 'TYPO3__DB__Connections__Default__host',
+                            'port' => 'TYPO3__DB__Connections__Default__port',
+                            'dbname' => 'TYPO3__DB__Connections__Default__dbname',
+                            'user' => 'TYPO3__DB__Connections__Default__user',
+                            'password' => 'TYPO3__DB__Connections__Default__password',
+                        ]
+                    );
+            }
+        ]
+    ]
+);

--- a/deployer/12/set.php
+++ b/deployer/12/set.php
@@ -80,6 +80,12 @@ set('db_databases',
                             'dbname' => 'TYPO3__DB__Connections__Default__dbname',
                             'user' => 'TYPO3__DB__Connections__Default__user',
                             'password' => 'TYPO3__DB__Connections__Default__password',
+                            'ssl_key' => 'TYPO3__DB__Connections__Default__ssl_key',
+                            'ssl_cert' => 'TYPO3__DB__Connections__Default__ssl_cert',
+                            'ssl_ca' => 'TYPO3__DB__Connections__Default__ssl_ca',
+                            'ssl_capath' => 'TYPO3__DB__Connections__Default__ssl_capath',
+                            'ssl_cipher' => 'TYPO3__DB__Connections__Default__ssl_cipher',
+                            'flags' => 'TYPO3__DB__Connections__Default__driverOptions__flags'
                         ]
                     );
             }

--- a/src/Drivers/Typo3CmsDriver.php
+++ b/src/Drivers/Typo3CmsDriver.php
@@ -13,8 +13,8 @@ class Typo3CmsDriver
 {
     public function getDatabaseConfig(string $databaseConfiguration = 'Default'): array
     {
-        exec($this->getPhpExecCommand() . ' ./vendor/bin/typo3cms configuration:showactive DB --json', $output,
-            $resultCode);
+        exec($this->getPhpExecCommand() . ' ' . $this->getTypo3ExecCommand() . ' configuration:showactive DB --json',
+            $output, $resultCode);
         if ($resultCode === 0) {
             return json_decode(implode("\n", $output), true, 512,
                 JSON_THROW_ON_ERROR)['Connections'][$databaseConfiguration];
@@ -30,5 +30,16 @@ class Typo3CmsDriver
             throw new RuntimeException('Failed to locate PHP binary to execute ' . $phpPath);
         }
         return $phpPath;
+    }
+
+    protected function getTypo3ExecCommand(): string
+    {
+        if (file_exists('./vendor/bin/typo3cms')) {
+            return './vendor/bin/typo3cms';
+        }
+        if (file_exists('./vendor/bin/typo3')) {
+            return './vendor/bin/typo3';
+        }
+        throw new RuntimeException('Could not find executable of TYPO3 console');
     }
 }


### PR DESCRIPTION
This adds basic support for v12. It's basically the v11 setting with little adjustments:

- Allow version 8 of typo3-console
- Add set.php for v12
- Find typo3(cms) binary in Typo3CmsDriver

Currently I have only one v12 test project. This configuration is working, however it needs further testing.